### PR TITLE
Allow overriding zIndex of BottomSheet

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -116,6 +116,8 @@ type Props = {
   callbackThreshold?: number
   borderRadius?: number
   overflow?: 'visible' | 'hidden'
+  // Defaults to 100
+  zIndex?: number
 }
 
 type State = {
@@ -793,6 +795,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
 
   render() {
     const { borderRadius } = this.props
+    const zIndex = this.props.zIndex || 100
     return (
       <>
         <Animated.View
@@ -807,7 +810,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
           style={{
             width: '100%',
             position: 'absolute',
-            zIndex: 100,
+            zIndex: zIndex,
             opacity: cond(this.height, 1, 0),
             transform: [
               {
@@ -832,7 +835,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
           >
             <Animated.View
               style={{
-                zIndex: 101,
+                zIndex: zIndex + 1,
               }}
               onLayout={this.handleLayoutHeader}
             >


### PR DESCRIPTION
# Context/Use case
We have a use case where we want to show a BottomSheet on top of another BottomSheet. One of the BottomSheet's is a draggable bar that is always visible while the other BottomSheet is a dropdown menu that animates from the bottom. We wanted the dropdown menu to animate up while the draggable bar remains stationary. The only way to lay both of these BottomSheet out is by setting the zIndex individually

# Solution
- Add a zIndex prop that defaults to the original value of 100